### PR TITLE
Add missing translations for Chinese, Japanese

### DIFF
--- a/internal/translations/locales/ja-JP/out.gotext.json
+++ b/internal/translations/locales/ja-JP/out.gotext.json
@@ -89,7 +89,7 @@
         {
             "id": "Show / Hide",
             "message": "Show / Hide",
-            "translation": ""
+            "translation": "表示 / 非表示"
         },
         {
             "id": "Settings",
@@ -114,12 +114,12 @@
         {
             "id": "Font",
             "message": "Font",
-            "translation": ""
+            "translation": "フォント"
         },
         {
             "id": "Logo",
             "message": "Logo",
-            "translation": ""
+            "translation": "ロゴ"
         },
         {
             "id": "Relay",
@@ -159,7 +159,7 @@
         {
             "id": "Multicast Address",
             "message": "Multicast Address",
-            "translation": ""
+            "translation": "マルチキャストアドレス"
         },
         {
             "id": "Transfer Options",

--- a/internal/translations/locales/zh-CN/out.gotext.json
+++ b/internal/translations/locales/zh-CN/out.gotext.json
@@ -89,7 +89,7 @@
         {
             "id": "Show / Hide",
             "message": "Show / Hide",
-            "translation": ""
+            "translation": "显示 / 隐藏"
         },
         {
             "id": "Settings",
@@ -119,7 +119,7 @@
         {
             "id": "Logo",
             "message": "Logo",
-            "translation": ""
+            "translation": "标志"
         },
         {
             "id": "Relay",
@@ -159,7 +159,7 @@
         {
             "id": "Multicast Address",
             "message": "Multicast Address",
-            "translation": ""
+            "translation": "组播地址"
         },
         {
             "id": "Transfer Options",

--- a/internal/translations/locales/zh-HK/out.gotext.json
+++ b/internal/translations/locales/zh-HK/out.gotext.json
@@ -89,7 +89,7 @@
         {
             "id": "Show / Hide",
             "message": "Show / Hide",
-            "translation": ""
+            "translation": "顯示 / 隱藏"
         },
         {
             "id": "Settings",
@@ -119,7 +119,7 @@
         {
             "id": "Logo",
             "message": "Logo",
-            "translation": ""
+            "translation": "標誌"
         },
         {
             "id": "Relay",
@@ -159,7 +159,7 @@
         {
             "id": "Multicast Address",
             "message": "Multicast Address",
-            "translation": ""
+            "translation": "群播位址"
         },
         {
             "id": "Transfer Options",

--- a/internal/translations/locales/zh-TW/out.gotext.json
+++ b/internal/translations/locales/zh-TW/out.gotext.json
@@ -89,7 +89,7 @@
         {
             "id": "Show / Hide",
             "message": "Show / Hide",
-            "translation": ""
+            "translation": "顯示 / 隱藏"
         },
         {
             "id": "Settings",
@@ -119,7 +119,7 @@
         {
             "id": "Logo",
             "message": "Logo",
-            "translation": ""
+            "translation": "標誌"
         },
         {
             "id": "Relay",
@@ -159,7 +159,7 @@
         {
             "id": "Multicast Address",
             "message": "Multicast Address",
-            "translation": ""
+            "translation": "群播位址"
         },
         {
             "id": "Transfer Options",


### PR DESCRIPTION
Adds translations for "Show / Hide", "Logo", and "Multicast Address" to support Chinese (zh-CN, zh-HK, zh-TW), Japanese (ja-JP).