### PR TITLE
Add FyneApp.toml to support fyne install

### DIFF
--- a/FyneApp.toml
+++ b/FyneApp.toml
@@ -1,0 +1,9 @@
+[Details]
+Icon = "metadata/en-US/images/icon.png"
+Name = "croc"
+ID = "com.github.howeyc.crocgui"
+Version = "1.11.7"
+Build = 42
+
+[Migrations]
+fyneDo = false

--- a/fdroid-build.sh
+++ b/fdroid-build.sh
@@ -14,10 +14,10 @@ go version
 go install fyne.io/fyne/v2/cmd/fyne\@v2.6.3
 fyne version
 if [[ $# -eq 0 ]]; then
-	fyne package -os android -release -appID com.github.howeyc.crocgui -icon metadata/en-US/images/icon.png
+	fyne package -os android -release
 	zip -d crocgui.apk "META-INF/*"
 else
-	fyne package -os android -appID com.github.howeyc.crocgui -icon metadata/en-US/images/icon.png
+	fyne package -os android
 fi
 chmod -R u+w gobuild
 rm -rf gobuild


### PR DESCRIPTION
This was originally reported as an issue in the Fyne CLI tools repository (https://github.com/fyne-io/tools/issues/85), and can easily be solved.

This PR adds a FyneApp.toml for the app build related configuration and uses it.

That should allow installing via:
```
fyne install github.com/howeyc/crocgui@latest
```